### PR TITLE
Add Chatwoot account selection & API listing

### DIFF
--- a/admin/admin-menu-and-tabs.php
+++ b/admin/admin-menu-and-tabs.php
@@ -147,7 +147,7 @@ class Disciple_Tools_Chatwoot_Tab_General {
         $integration_setup = isset( $settings['integration_setup'] ) ? $settings['integration_setup'] : false;
         $summarize_with_ai = isset( $settings['summarize_with_ai'] ) ? (bool) $settings['summarize_with_ai'] : true;
         $extract_contact_with_ai = isset( $settings['extract_contact_with_ai'] ) ? (bool) $settings['extract_contact_with_ai'] : true;
-        
+
         // Get available accounts if credentials are set
         $available_accounts = array();
         $selected_account_id = isset( $settings['account_id'] ) ? intval( $settings['account_id'] ) : 0;
@@ -269,7 +269,7 @@ class Disciple_Tools_Chatwoot_Tab_General {
             return;
         endif; ?>
 
-        <?php 
+        <?php
         // Check if account selection is needed
         $needs_account_selection = count( $available_accounts ) > 1 && empty( $selected_account_id );
         ?>
@@ -449,7 +449,7 @@ class Disciple_Tools_Chatwoot_Tab_General {
             // Handle account selection for multiple accounts
             if ( isset( $post_vars['chatwoot-account-id'] ) && !empty( $post_vars['chatwoot-account-id'] ) ) {
                 $account_id = intval( $post_vars['chatwoot-account-id'] );
-                
+
                 // Verify this is a valid account
                 $available_accounts = Disciple_Tools_Chatwoot_API::get_available_accounts();
                 $valid_account = false;
@@ -459,7 +459,7 @@ class Disciple_Tools_Chatwoot_Tab_General {
                         break;
                     }
                 }
-                
+
                 if ( $valid_account ) {
                     $settings['account_id'] = $account_id;
                 } else {
@@ -480,7 +480,7 @@ class Disciple_Tools_Chatwoot_Tab_General {
                     echo '<div class="notice notice-error"><p>Please select a Chatwoot account before enabling integration.</p></div>';
                     return;
                 }
-                
+
                 $result = $this->setup_chatwoot_integration( $token );
                 if ( $result === true ) {
                     echo '<div class="notice notice-success"><p>Integration enabled successfully! Chatwoot components created.</p></div>';
@@ -629,10 +629,10 @@ class Disciple_Tools_Chatwoot_Tab_General {
         }
 
         // Get account ID - use stored value if available, otherwise fetch
-        $account_id = isset( $settings['account_id'] ) && intval( $settings['account_id'] ) > 0 
+        $account_id = isset( $settings['account_id'] ) && intval( $settings['account_id'] ) > 0
             ? intval( $settings['account_id'] )
             : Disciple_Tools_Chatwoot_API::get_account_id();
-            
+
         if ( !$account_id ) {
             return 'Could not retrieve account information';
         }

--- a/admin/admin-menu-and-tabs.php
+++ b/admin/admin-menu-and-tabs.php
@@ -147,6 +147,13 @@ class Disciple_Tools_Chatwoot_Tab_General {
         $integration_setup = isset( $settings['integration_setup'] ) ? $settings['integration_setup'] : false;
         $summarize_with_ai = isset( $settings['summarize_with_ai'] ) ? (bool) $settings['summarize_with_ai'] : true;
         $extract_contact_with_ai = isset( $settings['extract_contact_with_ai'] ) ? (bool) $settings['extract_contact_with_ai'] : true;
+        
+        // Get available accounts if credentials are set
+        $available_accounts = array();
+        $selected_account_id = isset( $settings['account_id'] ) ? intval( $settings['account_id'] ) : 0;
+        if ( !empty( $chatwoot_url ) && !empty( $chatwoot_api_key ) ) {
+            $available_accounts = Disciple_Tools_Chatwoot_API::get_available_accounts();
+        }
         ?>
         <form method="post">
             <?php wp_nonce_field( 'dt_admin_form', 'dt_admin_form_nonce' ) ?>
@@ -221,8 +228,34 @@ class Disciple_Tools_Chatwoot_Tab_General {
                         </label>
                         <p class="description">Finds Name, phone numbers, emails, addresses, locations, language, age, and gender</p>
                     </td>
-                </tr>
+                </tr>                <?php if ( !empty( $available_accounts ) && count( $available_accounts ) > 1 ) : ?>
                 <tr>
+                    <td>
+                        <label for="chatwoot-account-id">Chatwoot Account <span style="color: red;">*</span></label>
+                    </td>
+                    <td>
+                        <select name="chatwoot-account-id" id="chatwoot-account-id" style="min-width: 300px;">
+                            <option value="">Select an account...</option>
+                            <?php foreach ( $available_accounts as $account ) : ?>
+                                <option value="<?php echo esc_attr( $account['id'] ); ?>" <?php selected( $selected_account_id, $account['id'] ); ?>>
+                                    <?php echo esc_html( $account['name'] ); ?> (ID: <?php echo esc_html( $account['id'] ); ?>)
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <p class="description">Multiple accounts found. Select the account you want to connect to this Disciple.Tools instance.</p>
+                    </td>
+                </tr>
+                <?php elseif ( !empty( $available_accounts ) && count( $available_accounts ) === 1 ) : ?>
+                <tr>
+                    <td>
+                        <label>Chatwoot Account</label>
+                    </td>
+                    <td>
+                        <strong><?php echo esc_html( $available_accounts[0]['name'] ); ?></strong> (ID: <?php echo esc_html( $available_accounts[0]['id'] ); ?>)
+                        <p class="description">Automatically selected (only one account available)</p>
+                    </td>
+                </tr>
+                <?php endif; ?>                <tr>
                     <td>
                         <button class="button button-primary">Save Settings</button>
                     </td>
@@ -235,6 +268,11 @@ class Disciple_Tools_Chatwoot_Tab_General {
         <?php if ( empty( $chatwoot_url ) || empty( $chatwoot_api_key ) ) :
             return;
         endif; ?>
+
+        <?php 
+        // Check if account selection is needed
+        $needs_account_selection = count( $available_accounts ) > 1 && empty( $selected_account_id );
+        ?>
 
         <?php if ( $integration_setup ) : ?>
             <?php $this->render_inbox_source_mapping( $token, $settings ); ?>
@@ -320,6 +358,13 @@ class Disciple_Tools_Chatwoot_Tab_General {
                         </div>
 
                         <?php if ( !$integration_setup ): ?>
+                            <?php if ( $needs_account_selection ): ?>
+                                <div style="background: #fff3cd; border: 1px solid #ffeaa7; border-radius: 4px; padding: 15px; margin-bottom: 15px; text-align: center;">
+                                    <p style="margin: 0; color: #856404; font-weight: 500;">
+                                        ⚠️ Please select a Chatwoot account in the settings above before enabling integration.
+                                    </p>
+                                </div>
+                            <?php else: ?>
                             <div style="text-align: center;">
                                 <button type="submit" name="enable-integration" value="1" class="button" style="
                                     background: #00a32a;
@@ -340,6 +385,7 @@ class Disciple_Tools_Chatwoot_Tab_General {
                                     🚀 Enable Integration Now
                                 </button>
                             </div>
+                            <?php endif; ?>
                         <?php endif; ?>
                     </div>
                 </form>
@@ -400,12 +446,41 @@ class Disciple_Tools_Chatwoot_Tab_General {
                 $settings['default_assigned_user'] = sanitize_text_field( $post_vars['default-assigned-user'] );
             }
 
+            // Handle account selection for multiple accounts
+            if ( isset( $post_vars['chatwoot-account-id'] ) && !empty( $post_vars['chatwoot-account-id'] ) ) {
+                $account_id = intval( $post_vars['chatwoot-account-id'] );
+                
+                // Verify this is a valid account
+                $available_accounts = Disciple_Tools_Chatwoot_API::get_available_accounts();
+                $valid_account = false;
+                foreach ( $available_accounts as $account ) {
+                    if ( intval( $account['id'] ) === $account_id ) {
+                        $valid_account = true;
+                        break;
+                    }
+                }
+                
+                if ( $valid_account ) {
+                    $settings['account_id'] = $account_id;
+                } else {
+                    echo '<div class="notice notice-error"><p>Invalid account selected.</p></div>';
+                    return;
+                }
+            }
+
             $settings['summarize_with_ai'] = isset( $post_vars['chatwoot-summarize-with-ai'] ) ? '1' : '0';
             $settings['extract_contact_with_ai'] = isset( $post_vars['chatwoot-extract-contact-with-ai'] ) ? '1' : '0';
 
             update_option( $token, $settings );
 
             if ( isset( $post_vars['enable-integration'] ) && $post_vars['enable-integration'] == '1' ) {
+                // Check if account is selected (for multiple accounts)
+                $available_accounts = Disciple_Tools_Chatwoot_API::get_available_accounts();
+                if ( count( $available_accounts ) > 1 && empty( $settings['account_id'] ) ) {
+                    echo '<div class="notice notice-error"><p>Please select a Chatwoot account before enabling integration.</p></div>';
+                    return;
+                }
+                
                 $result = $this->setup_chatwoot_integration( $token );
                 if ( $result === true ) {
                     echo '<div class="notice notice-success"><p>Integration enabled successfully! Chatwoot components created.</p></div>';
@@ -553,8 +628,11 @@ class Disciple_Tools_Chatwoot_Tab_General {
             return 'Missing Chatwoot URL or API key';
         }
 
-        // Get account ID first (needed for API calls)
-        $account_id = Disciple_Tools_Chatwoot_API::get_account_id( true );
+        // Get account ID - use stored value if available, otherwise fetch
+        $account_id = isset( $settings['account_id'] ) && intval( $settings['account_id'] ) > 0 
+            ? intval( $settings['account_id'] )
+            : Disciple_Tools_Chatwoot_API::get_account_id();
+            
         if ( !$account_id ) {
             return 'Could not retrieve account information';
         }

--- a/admin/admin-menu-and-tabs.php
+++ b/admin/admin-menu-and-tabs.php
@@ -364,7 +364,7 @@ class Disciple_Tools_Chatwoot_Tab_General {
                                         ⚠️ Please select a Chatwoot account in the settings above before enabling integration.
                                     </p>
                                 </div>
-                            <?php else: ?>
+                            <?php else : ?>
                             <div style="text-align: center;">
                                 <button type="submit" name="enable-integration" value="1" class="button" style="
                                     background: #00a32a;

--- a/functions/chatwoot-api.php
+++ b/functions/chatwoot-api.php
@@ -218,9 +218,7 @@ class Disciple_Tools_Chatwoot_API
                 dt_write_log( 'Reached maximum page limit (' . $max_pages . ') when fetching conversation' );
                 break;
             }
-
         } while ( true );
-
         if ( !empty( $all_messages ) ) {
             dt_write_log( 'Successfully fetched ' . count( $all_messages ) . ' messages across ' . $page . ' page(s) for conversation ' . $conversation_id );
         }

--- a/functions/chatwoot-api.php
+++ b/functions/chatwoot-api.php
@@ -313,15 +313,71 @@ class Disciple_Tools_Chatwoot_API
             return false;
         }
 
-        $account_id = self::fetch_account_id_from_api( $chatwoot_url, $chatwoot_api_key );
-        if ( !$account_id ) {
+        // Get all accounts
+        $accounts = self::get_available_accounts( $chatwoot_url, $chatwoot_api_key );
+        if ( empty( $accounts ) ) {
             return false;
         }
 
-        $settings['account_id'] = intval( $account_id );
-        update_option( 'dt_chatwoot', $settings );
+        // If only one account, auto-select it
+        if ( count( $accounts ) === 1 ) {
+            $account_id = intval( $accounts[0]['id'] );
+            $settings['account_id'] = $account_id;
+            update_option( 'dt_chatwoot', $settings );
+            return $account_id;
+        }
 
-        return intval( $account_id );
+        // Multiple accounts - user must select one
+        // Return false if no account is selected yet
+        return false;
+    }
+
+    public static function get_available_accounts( $chatwoot_url = null, $api_key = null ) {
+        if ( $chatwoot_url === null ) {
+            $chatwoot_url = self::get_chatwoot_url();
+        }
+        if ( $api_key === null ) {
+            $api_key = self::get_chatwoot_api_key();
+        }
+
+        if ( empty( $chatwoot_url ) || empty( $api_key ) ) {
+            return array();
+        }
+
+        $api_url = untrailingslashit( $chatwoot_url ) . '/api/v1/profile';
+
+        $response = wp_remote_get( $api_url, array(
+            'headers' => array(
+                'Content-Type' => 'application/json',
+                'api_access_token' => $api_key,
+            ),
+            'timeout' => 30
+        ));
+
+        if ( is_wp_error( $response ) ) {
+            dt_write_log( 'Error fetching user profile: ' . $response->get_error_message() );
+            return array();
+        }
+
+        $response_code = wp_remote_retrieve_response_code( $response );
+        if ( $response_code !== 200 ) {
+            dt_write_log( 'Failed to fetch user profile. Response code: ' . $response_code );
+            return array();
+        }
+
+        $body = wp_remote_retrieve_body( $response );
+        $data = json_decode( $body, true );
+
+        if ( json_last_error() !== JSON_ERROR_NONE || empty( $data ) ) {
+            dt_write_log( 'Error parsing user profile response' );
+            return array();
+        }
+
+        if ( isset( $data['accounts'] ) && is_array( $data['accounts'] ) ) {
+            return $data['accounts'];
+        }
+
+        return array();
     }
 
     public static function get_chatwoot_inboxes( $force_refresh = false ) {
@@ -443,40 +499,11 @@ class Disciple_Tools_Chatwoot_API
     }
 
     private static function fetch_account_id_from_api( $chatwoot_url, $api_key ) {
-        $api_url = untrailingslashit( $chatwoot_url ) . '/api/v1/profile';
-
-        $response = wp_remote_get( $api_url, array(
-            'headers' => array(
-                'Content-Type' => 'application/json',
-                'api_access_token' => $api_key,
-            ),
-            'timeout' => 30
-        ));
-
-        if ( is_wp_error( $response ) ) {
-            dt_write_log( 'Error fetching user profile: ' . $response->get_error_message() );
-            return false;
+        // This method is deprecated - use get_available_accounts() instead
+        $accounts = self::get_available_accounts( $chatwoot_url, $api_key );
+        if ( !empty( $accounts ) ) {
+            return intval( $accounts[0]['id'] );
         }
-
-        $response_code = wp_remote_retrieve_response_code( $response );
-        if ( $response_code !== 200 ) {
-            dt_write_log( 'Failed to fetch user profile. Response code: ' . $response_code );
-            return false;
-        }
-
-        $body = wp_remote_retrieve_body( $response );
-        $data = json_decode( $body, true );
-
-        if ( json_last_error() !== JSON_ERROR_NONE || empty( $data ) ) {
-            dt_write_log( 'Error parsing user profile response' );
-            return false;
-        }
-
-        if ( isset( $data['accounts'] ) && !empty( $data['accounts'] ) ) {
-            return intval( $data['accounts'][0]['id'] );
-        }
-
-        dt_write_log( 'No accounts found for user' );
         return false;
     }
 }

--- a/functions/chatwoot-api.php
+++ b/functions/chatwoot-api.php
@@ -325,8 +325,21 @@ class Disciple_Tools_Chatwoot_API
             return $account_id;
         }
 
-        // Multiple accounts - user must select one
-        // Return false if no account is selected yet
+        // Multiple accounts - check if stored account is still valid
+        $stored_account_id = isset( $settings['account_id'] ) ? intval( $settings['account_id'] ) : 0;
+        if ( $stored_account_id > 0 ) {
+            foreach ( $accounts as $account ) {
+                if ( intval( $account['id'] ) === $stored_account_id ) {
+                    // Stored account is still valid
+                    return $stored_account_id;
+                }
+            }
+            // Stored account is no longer valid, clear it
+            unset( $settings['account_id'] );
+            update_option( 'dt_chatwoot', $settings );
+        }
+
+        // Multiple accounts and no valid selection - user must select one
         return false;
     }
 


### PR DESCRIPTION
Add UI and API support for selecting Chatwoot accounts. The admin tab now fetches available Chatwoot accounts when credentials are present and shows a dropdown if multiple accounts exist (auto-selects and displays if only one). Saving validates the selected account and stores it in settings['account_id']; enabling integration is blocked until an account is chosen. In the API layer, added get_available_accounts() to list accounts from /api/v1/profile, updated account retrieval to auto-select a single account or require explicit selection when multiple accounts exist, and deprecated the old fetch_account_id_from_api() behavior to use the new function.